### PR TITLE
nick_dropped should not penalize

### DIFF
--- a/dawdle.py
+++ b/dawdle.py
@@ -1479,10 +1479,12 @@ class DawdleBot(object):
 
 
     def nick_dropped(self, src):
-        """Called when someone was disconnected."""
+        """Called when someone was disconnected through no fault of their own."""
         player = self._players.from_nick(src)
         if player:
+            player.online = False
             player.lastlogin = time.time()
+            self._players.write()
 
 
     def nick_quit(self, src):


### PR DESCRIPTION
Actually set a player offline when they go offline via ping timeout or read error, so that they don't get a drop penalty after the split timeout occurs. We intentionally want no penalty here.

Alternative: we could make this another penalty type and configure it to zero.